### PR TITLE
Deprecate non-prefixed ENV vars, but still support them

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,7 +16,13 @@ class Config(object):
         self.config = yaml.load(blob)
 
     def __getattr__(self, attrname):
-        envvar = os.getenv('DESTALINATOR_' + attrname.upper())
+
+        upper_attrname = attrname.upper()
+        envvar = os.getenv(upper_attrname)
+        if envvar is not None:
+            warnings.warn("The %s environment variable is deprecated in favor of the `DESTALINATOR_%s` environment variable".format(upper_attrname, upper_attrname), DeprecationWarning)
+        else:
+            envvar = os.getenv('DESTALINATOR_' + upper_attrname)
         if envvar is not None:
             return envvar.split(',') if ',' in envvar else envvar
 

--- a/executor.py
+++ b/executor.py
@@ -20,7 +20,7 @@ class Executor(WithLogger):
         self.slackbot = slackbot_injected or slackbot.Slackbot(config.slack_name, token=slackbot_token)
         set_up_slack_logger(self.slackbot)
 
-        self.activated = self.config.activated == 'true'
+        self.activated = self.config.activated
         self.logger.debug("activated is %s", self.activated)
 
         self.slacker = slacker_injected or slacker.Slacker(config.slack_name, token=api_token)


### PR DESCRIPTION
This should help make merging randsleadershipslack/destalinator#122 easier. Trying this out on my work slack.